### PR TITLE
c_v gave full score, 1.0, for clusters where none of the words ever occured in the same document

### DIFF
--- a/palmetto/src/main/java/org/aksw/palmetto/calculations/indirect/CosinusConfirmationMeasure.java
+++ b/palmetto/src/main/java/org/aksw/palmetto/calculations/indirect/CosinusConfirmationMeasure.java
@@ -35,11 +35,7 @@ public class CosinusConfirmationMeasure extends AbstractVectorBasedCalculation {
         if ((length1 > 0) && (length2 > 0)) {
             return sum / (Math.sqrt(length1) * Math.sqrt(length2));
         } else {
-            if ((length1 == 0) && (length2 == 0)) {
-                return 1;
-            } else {
-                return 0;
-            }
+            return 0;
         }
     }
 

--- a/palmetto/src/test/java/org/aksw/palmetto/calculations/indirect/CosinusBasedCalculationTest.java
+++ b/palmetto/src/test/java/org/aksw/palmetto/calculations/indirect/CosinusBasedCalculationTest.java
@@ -66,10 +66,8 @@ public class CosinusBasedCalculationTest extends AbstractVectorBasedCalculationT
                  * vector2 0 0 0
                  * 
                  * cos=0/(sqrt(0)*sqrt(0))=0
-                 * 
-                 * but we define this as 1, because vector1 == vector2
                  */
-                { new double[] { 0, 0, 0 }, new double[] { 0, 0, 0 }, 1.0 },
+                { new double[] { 0, 0, 0 }, new double[] { 0, 0, 0 }, 0 },
                 /*
                  * vector1 2/3 1/3 1/3
                  * 


### PR DESCRIPTION
I encountered this problem while evaluating fast-text clusters for a corpus of a million articles from nrk.no.
  I fixed it by redefining cosine similarity for the case when both term frequency vectors are length 0.
  Cosine similarity for two 0 length vectors is now set to 0.
  Clusters with no similarity now get score 0.